### PR TITLE
fix: correct syntax in .env.example for homepage template

### DIFF
--- a/templates/homepage/.env.example
+++ b/templates/homepage/.env.example
@@ -1,3 +1,3 @@
-HOMEPAGE_ALLOWED_HOSTS: gethomepage.dev # required, may need port. See gethomepage.dev/installation/#homepage_allowed_hosts
-PUID: 1000
-PGID: 1000 
+HOMEPAGE_ALLOWED_HOSTS=gethomepage.dev # required, may need port. See gethomepage.dev/installation/#homepage_allowed_hosts
+PUID=1000
+PGID=1000


### PR DESCRIPTION
Minor correction to .env.example  swapping colons (:) to equals (=)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the format of environment variable examples to use equal signs (`=`) for better compatibility with standard `.env` files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->