### PR TITLE
feat: add Windshift template

### DIFF
--- a/templates/windshift/.env.example
+++ b/templates/windshift/.env.example
@@ -1,8 +1,8 @@
 # Windshift
-# Keep BASE_URL aligned with the URL used to access Windshift. For production,
-# use an HTTPS URL served by your reverse proxy.
+# Leave BASE_URL empty to derive http://localhost:<APP_PORT>. For production,
+# set it to the HTTPS URL served by your reverse proxy.
 APP_PORT=8080
-BASE_URL=http://localhost:8080
+BASE_URL=
 WINDSHIFT_VERSION=0.8.3
 
 # Generate with: openssl rand -hex 32
@@ -12,4 +12,3 @@ SSO_SECRET=change-this-to-a-random-64-character-hex-secret
 POSTGRES_USER=windshift
 POSTGRES_PASSWORD=change-this-to-a-strong-database-password
 POSTGRES_DB=windshift
-POSTGRES_VERSION=17

--- a/templates/windshift/.env.example
+++ b/templates/windshift/.env.example
@@ -1,0 +1,15 @@
+# Windshift
+# Keep BASE_URL aligned with the URL used to access Windshift. For production,
+# use an HTTPS URL served by your reverse proxy.
+APP_PORT=8080
+BASE_URL=http://localhost:8080
+WINDSHIFT_VERSION=0.8.3
+
+# Generate with: openssl rand -hex 32
+SSO_SECRET=change-this-to-a-random-64-character-hex-secret
+
+# PostgreSQL
+POSTGRES_USER=windshift
+POSTGRES_PASSWORD=change-this-to-a-strong-database-password
+POSTGRES_DB=windshift
+POSTGRES_VERSION=17

--- a/templates/windshift/README.md
+++ b/templates/windshift/README.md
@@ -1,0 +1,21 @@
+# Windshift
+
+[Windshift](https://windshift.sh/) is a self-hosted work management platform for planning projects, shaping workflows, and collaborating while keeping control of your data.
+
+## Before deploying
+
+Review the template environment variables:
+
+1. Set `BASE_URL` to the complete URL you will use to access Windshift. Keep `APP_PORT` and the port in `BASE_URL` aligned when running on localhost.
+2. Replace `SSO_SECRET` with the output of `openssl rand -hex 32`.
+3. Replace `POSTGRES_PASSWORD` with a strong, unique password.
+
+For a production deployment, put Windshift behind an HTTPS reverse proxy and set `BASE_URL` to its public HTTPS URL. Windshift automatically detects proxy mode when `BASE_URL` uses HTTPS and the container does not have a TLS certificate.
+
+## First run
+
+Deploy the project, open the configured `BASE_URL`, and follow the setup wizard to create the first administrator and workspace.
+
+The `windshift-data` volume stores attachments, plugins, and other application data. The `postgres-data` volume stores the database. Back up both volumes.
+
+See the [Windshift documentation](https://windshift.sh/docs) for configuration, integrations, and upgrades.

--- a/templates/windshift/README.md
+++ b/templates/windshift/README.md
@@ -6,7 +6,7 @@
 
 Review the template environment variables:
 
-1. Set `BASE_URL` to the complete URL you will use to access Windshift. Keep `APP_PORT` and the port in `BASE_URL` aligned when running on localhost.
+1. Leave `BASE_URL` empty to use `http://localhost:<APP_PORT>`, or set it to the complete public URL you will use to access Windshift.
 2. Replace `SSO_SECRET` with the output of `openssl rand -hex 32`.
 3. Replace `POSTGRES_PASSWORD` with a strong, unique password.
 

--- a/templates/windshift/compose.yaml
+++ b/templates/windshift/compose.yaml
@@ -1,0 +1,59 @@
+x-arcane:
+  icon: https://windshift.sh/favicon-32x32.png
+  urls:
+    - https://windshift.sh/
+    - https://github.com/Windshiftapp/core
+
+services:
+  windshift:
+    image: ghcr.io/windshiftapp/windshift:v${WINDSHIFT_VERSION:-0.8.3}
+    restart: unless-stopped
+    ports:
+      - "${APP_PORT:-8080}:8080"
+    environment:
+      BASE_URL: ${BASE_URL:-http://localhost:8080}
+      PORT: 8080
+      SSO_SECRET: ${SSO_SECRET}
+      ATTACHMENT_PATH: /data/attachments
+      DB_TYPE: postgres
+      POSTGRES_HOST: db
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: ${POSTGRES_USER:-windshift}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-windshift}
+      LOG_LEVEL: info
+      LOG_FORMAT: json
+    volumes:
+      - windshift-data:/data
+    tmpfs:
+      - /tmp:exec,size=64M
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+    depends_on:
+      db:
+        condition: service_healthy
+    labels:
+      com.getarcaneapp.arcane.icon: https://windshift.sh/favicon-32x32.png
+
+  db:
+    image: postgres:${POSTGRES_VERSION:-17}
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-windshift}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-windshift}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    labels:
+      com.getarcaneapp.arcane.icon: https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/postgresql.svg
+
+volumes:
+  windshift-data:
+  postgres-data:

--- a/templates/windshift/compose.yaml
+++ b/templates/windshift/compose.yaml
@@ -11,7 +11,7 @@ services:
     ports:
       - "${APP_PORT:-8080}:8080"
     environment:
-      BASE_URL: ${BASE_URL:-http://localhost:8080}
+      BASE_URL: ${BASE_URL:-http://localhost:${APP_PORT:-8080}}
       PORT: 8080
       SSO_SECRET: ${SSO_SECRET}
       ATTACHMENT_PATH: /data/attachments
@@ -38,7 +38,7 @@ services:
       com.getarcaneapp.arcane.icon: https://windshift.sh/favicon-32x32.png
 
   db:
-    image: postgres:${POSTGRES_VERSION:-17}
+    image: postgres:17
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-windshift}

--- a/templates/windshift/template.json
+++ b/templates/windshift/template.json
@@ -1,0 +1,7 @@
+{
+  "name": "Windshift",
+  "description": "Self-hosted work management for projects, workflows, collaboration, and delivery.",
+  "version": "1.0.0",
+  "author": "Windshift",
+  "tags": ["project-management", "work-management", "productivity"]
+}


### PR DESCRIPTION
## Summary

- add a Windshift v0.8.3 template backed by PostgreSQL 17
- expose Arcane-configurable application URL, port, image version, and credentials
- persist Windshift and PostgreSQL data and document first-run, proxy, secret, and backup setup

## Validation

- Vite+ format check passed
- Vite+ check passed (format, lint, and type checks)
- registry generation and schema validation passed for 75 templates
- Docker Compose validation passed for all 75 templates
- registry test suite passed (14 tests)
- published image manifest contains Linux amd64 and arm64 images
- clean local deployment passed: PostgreSQL became healthy, the root route returned HTTP 200, and /api/version reported 0.8.3

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a Windshift deployment template.
- Runs Windshift v0.8.3 with PostgreSQL 17 and persistent application and database volumes.
- Exposes application URL, host port, image versions, and credentials through environment variables.
- Documents first-run setup, reverse-proxy configuration, secret replacement, and backups.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The configurable host port must remain synchronized with Windshift's public URL before the template is safe to merge.

Changing APP_PORT independently leaves BASE_URL on port 8080, causing URL-dependent authentication, verification, WebAuthn, calendar, and runner flows to use the wrong address; PostgreSQL major-version changes also need migration guidance.

**Files Needing Attention:** templates/windshift/compose.yaml, templates/windshift/.env.example, templates/windshift/README.md
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Ftemplates%22%20on%20the%20existing%20branch%20%22feat%2Fwindshift-template%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fwindshift-template%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atemplates%2Fwindshift%2Fcompose.yaml%3A41%0A**Editable%20PostgreSQL%20major%20version**%0A%0A%60POSTGRES_VERSION%60%20is%20presented%20as%20an%20ordinary%20deployment%20setting%20while%20every%20version%20reuses%20the%20same%20%60postgres-data%60%20volume.%20Document%20that%20changing%20the%20major%20version%20requires%20a%20dump%2Frestore%20or%20%60pg_upgrade%60%2C%20or%20pin%20the%20image%20here%3B%20otherwise%20an%20upgrade%20from%2017%20to%2018%20starts%20PostgreSQL%20against%20an%20incompatible%20data%20directory%20and%20leaves%20Windshift%20unavailable.%0A%0A%23%23%23%20Issue%202%20of%202%0Atemplates%2Fwindshift%2Fcompose.yaml%3A12%0A**Custom%20port%20leaves%20URL%20stale**%0A%0AWhen%20a%20user%20changes%20%60APP_PORT%60%20but%20retains%20the%20provided%20%60BASE_URL%60%2C%20Windshift%20remains%20configured%20with%20%60http%3A%2F%2Flocalhost%3A8080%60%20while%20users%20access%20the%20service%20on%20the%20new%20port.%20Windshift%20uses%20%60BASE_URL%60%20for%20SSO%20redirects%2C%20email%20links%2C%20WebAuthn%20origins%2C%20calendar%20feeds%2C%20and%20runner%20callbacks%2C%20so%20those%20flows%20target%20the%20wrong%20address.%20Couple%20these%20settings%20or%20derive%20the%20localhost%20URL%20from%20the%20selected%20host%20port%20rather%20than%20relying%20only%20on%20the%20README%20warning.%0A%0A&repo=getarcaneapp%2Ftemplates&pr=163&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atemplates%2Fwindshift%2Fcompose.yaml%3A41%0A**Editable%20PostgreSQL%20major%20version**%0A%0A%60POSTGRES_VERSION%60%20is%20presented%20as%20an%20ordinary%20deployment%20setting%20while%20every%20version%20reuses%20the%20same%20%60postgres-data%60%20volume.%20Document%20that%20changing%20the%20major%20version%20requires%20a%20dump%2Frestore%20or%20%60pg_upgrade%60%2C%20or%20pin%20the%20image%20here%3B%20otherwise%20an%20upgrade%20from%2017%20to%2018%20starts%20PostgreSQL%20against%20an%20incompatible%20data%20directory%20and%20leaves%20Windshift%20unavailable.%0A%0A%23%23%23%20Issue%202%20of%202%0Atemplates%2Fwindshift%2Fcompose.yaml%3A12%0A**Custom%20port%20leaves%20URL%20stale**%0A%0AWhen%20a%20user%20changes%20%60APP_PORT%60%20but%20retains%20the%20provided%20%60BASE_URL%60%2C%20Windshift%20remains%20configured%20with%20%60http%3A%2F%2Flocalhost%3A8080%60%20while%20users%20access%20the%20service%20on%20the%20new%20port.%20Windshift%20uses%20%60BASE_URL%60%20for%20SSO%20redirects%2C%20email%20links%2C%20WebAuthn%20origins%2C%20calendar%20feeds%2C%20and%20runner%20callbacks%2C%20so%20those%20flows%20target%20the%20wrong%20address.%20Couple%20these%20settings%20or%20derive%20the%20localhost%20URL%20from%20the%20selected%20host%20port%20rather%20than%20relying%20only%20on%20the%20README%20warning.%0A%0A&repo=getarcaneapp%2Ftemplates&pr=163&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
templates/windshift/compose.yaml:41
**Editable PostgreSQL major version**

`POSTGRES_VERSION` is presented as an ordinary deployment setting while every version reuses the same `postgres-data` volume. Document that changing the major version requires a dump/restore or `pg_upgrade`, or pin the image here; otherwise an upgrade from 17 to 18 starts PostgreSQL against an incompatible data directory and leaves Windshift unavailable.

### Issue 2 of 2
templates/windshift/compose.yaml:12
**Custom port leaves URL stale**

When a user changes `APP_PORT` but retains the provided `BASE_URL`, Windshift remains configured with `http://localhost:8080` while users access the service on the new port. Windshift uses `BASE_URL` for SSO redirects, email links, WebAuthn origins, calendar feeds, and runner callbacks, so those flows target the wrong address. Couple these settings or derive the localhost URL from the selected host port rather than relying only on the README warning.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add Windshift template"](https://github.com/getarcaneapp/templates/commit/40cc337b6a3a29d4d75f464af7d0f57304d418c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47542045)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->