### PR TITLE
feat: add DockRoute template

### DIFF
--- a/templates/dockroute/.env.example
+++ b/templates/dockroute/.env.example
@@ -30,7 +30,3 @@ CLOUDFLARE_API_TOKEN=
 # running cloudflared yourself).
 CLOUDFLARE_ACCOUNT_ID=
 CLOUDFLARE_TUNNEL_ID=
-
-# Group id that owns /var/run/docker.sock on the host, so the non-root
-# container user can read the socket:  stat -c '%g' /var/run/docker.sock
-DOCKER_SOCK_GID=0

--- a/templates/dockroute/.env.example
+++ b/templates/dockroute/.env.example
@@ -1,0 +1,36 @@
+# DNS provider: "log" is a zero-credential dry run that only prints the
+# desired state; switch to "cloudflare" when you are ready.
+DOCKROUTE_PROVIDER=log
+
+# Ownership id written to companion TXT records; lets several DockRoute
+# instances share a zone safely.
+DOCKROUTE_OWNER_ID=default
+
+# sync = create/update/delete owned records; upsert-only = never delete;
+# create-only = never update or delete.
+DOCKROUTE_POLICY=sync
+
+# Fallback record value (IP or CNAME target) when a container omits the
+# dockroute.target label. E.g. your server's LAN or WAN IP.
+DOCKROUTE_DEFAULT_TARGET=
+
+# Optional comma-separated allowlist of DNS zones DockRoute may touch.
+# Empty = all zones the token can see.
+DOCKROUTE_DOMAIN_FILTER=
+
+# Interval of the periodic full reconcile that backs up the event stream.
+DOCKROUTE_RESYNC_SECONDS=60
+
+# Required when DOCKROUTE_PROVIDER=cloudflare.
+# Token permissions: Zone -> DNS -> Edit
+# (+ Account -> Cloudflare Tunnel -> Edit for tunnel publishing).
+CLOUDFLARE_API_TOKEN=
+
+# Only needed for Cloudflare Tunnel publishing (existing tunnel — you keep
+# running cloudflared yourself).
+CLOUDFLARE_ACCOUNT_ID=
+CLOUDFLARE_TUNNEL_ID=
+
+# Group id that owns /var/run/docker.sock on the host, so the non-root
+# container user can read the socket:  stat -c '%g' /var/run/docker.sock
+DOCKER_SOCK_GID=0

--- a/templates/dockroute/README.md
+++ b/templates/dockroute/README.md
@@ -29,5 +29,4 @@ services:
       dockroute.tunnel.service: "http://whoami:80"
 ```
 
-Full label and configuration reference:
-https://github.com/Dockroute/Dockroute#readme
+Full label and configuration reference: https://www.dockroute.dev

--- a/templates/dockroute/README.md
+++ b/templates/dockroute/README.md
@@ -12,12 +12,11 @@ logged and skipped.
 
 ## Setup
 
-1. Set `DOCKER_SOCK_GID` in the environment to the group that owns your
-   Docker socket (`stat -c '%g' /var/run/docker.sock`) — the image runs as a
-   non-root user.
-2. Leave `DOCKROUTE_PROVIDER=log` for a zero-credential dry run, or set it to
-   `cloudflare` and fill in `CLOUDFLARE_API_TOKEN`.
-3. Opt containers in with labels:
+1. Leave `DOCKROUTE_PROVIDER=log` for a zero-credential dry run, or set it to
+   `cloudflare` and fill in `CLOUDFLARE_API_TOKEN`. Socket permissions are
+   handled automatically — the entrypoint grants the app user the socket's
+   group and drops privileges.
+2. Opt containers in with labels:
 
 ```yaml
 services:

--- a/templates/dockroute/README.md
+++ b/templates/dockroute/README.md
@@ -1,0 +1,34 @@
+# DockRoute
+
+External-DNS for plain Docker hosts — the same idea as Kubernetes
+[external-dns](https://github.com/kubernetes-sigs/external-dns), but for a
+single Docker machine. DockRoute watches your running containers, reads
+`dockroute.*` labels and reconciles the matching DNS records (and Cloudflare
+Tunnel routes) in a pluggable provider.
+
+It **never alters what it cannot prove it manages**: every record it creates
+gets a companion TXT ownership record, and anything without that proof is
+logged and skipped.
+
+## Setup
+
+1. Set `DOCKER_SOCK_GID` in the environment to the group that owns your
+   Docker socket (`stat -c '%g' /var/run/docker.sock`) — the image runs as a
+   non-root user.
+2. Leave `DOCKROUTE_PROVIDER=log` for a zero-credential dry run, or set it to
+   `cloudflare` and fill in `CLOUDFLARE_API_TOKEN`.
+3. Opt containers in with labels:
+
+```yaml
+services:
+  whoami:
+    image: traefik/whoami
+    labels:
+      dockroute.enabled: "true"
+      dockroute.hostname: "whoami.example.com"
+      # optional — publish through an existing Cloudflare Tunnel:
+      dockroute.tunnel.service: "http://whoami:80"
+```
+
+Full label and configuration reference:
+https://github.com/Dockroute/Dockroute#readme

--- a/templates/dockroute/compose.yml
+++ b/templates/dockroute/compose.yml
@@ -1,0 +1,28 @@
+x-arcane:
+  icon: https://github.com/Dockroute.png
+  urls:
+    - https://github.com/Dockroute/Dockroute
+
+services:
+  dockroute:
+    image: ghcr.io/dockroute/dockroute:latest
+    container_name: dockroute
+    restart: unless-stopped
+    environment:
+      DOCKROUTE_PROVIDER: ${DOCKROUTE_PROVIDER:-log}
+      DOCKROUTE_OWNER_ID: ${DOCKROUTE_OWNER_ID:-default}
+      DOCKROUTE_POLICY: ${DOCKROUTE_POLICY:-sync}
+      DOCKROUTE_DEFAULT_TARGET: ${DOCKROUTE_DEFAULT_TARGET:-}
+      DOCKROUTE_DOMAIN_FILTER: ${DOCKROUTE_DOMAIN_FILTER:-}
+      DOCKROUTE_RESYNC_SECONDS: ${DOCKROUTE_RESYNC_SECONDS:-60}
+      CLOUDFLARE_API_TOKEN: ${CLOUDFLARE_API_TOKEN:-}
+      CLOUDFLARE_ACCOUNT_ID: ${CLOUDFLARE_ACCOUNT_ID:-}
+      CLOUDFLARE_TUNNEL_ID: ${CLOUDFLARE_TUNNEL_ID:-}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    # The image runs as a non-root user; grant it the group that owns the
+    # Docker socket:  stat -c '%g' /var/run/docker.sock
+    group_add:
+      - "${DOCKER_SOCK_GID:-0}"
+    labels:
+      com.getarcaneapp.arcane.icon: https://github.com/Dockroute.png

--- a/templates/dockroute/compose.yml
+++ b/templates/dockroute/compose.yml
@@ -20,9 +20,5 @@ services:
       CLOUDFLARE_TUNNEL_ID: ${CLOUDFLARE_TUNNEL_ID:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    # The image runs as a non-root user; grant it the group that owns the
-    # Docker socket:  stat -c '%g' /var/run/docker.sock
-    group_add:
-      - "${DOCKER_SOCK_GID:-0}"
     labels:
       com.getarcaneapp.arcane.icon: https://github.com/Dockroute.png

--- a/templates/dockroute/compose.yml
+++ b/templates/dockroute/compose.yml
@@ -1,6 +1,7 @@
 x-arcane:
   icon: https://github.com/Dockroute.png
   urls:
+    - https://www.dockroute.dev
     - https://github.com/Dockroute/Dockroute
 
 services:

--- a/templates/dockroute/template.json
+++ b/templates/dockroute/template.json
@@ -1,0 +1,7 @@
+{
+  "name": "DockRoute",
+  "description": "External-DNS for plain Docker hosts — reconciles DNS records and Cloudflare Tunnel routes from container labels.",
+  "version": "1.0.0",
+  "author": "danilodorgam",
+  "tags": ["dns", "networking", "automation", "cloudflare", "docker"]
+}


### PR DESCRIPTION
## What

Adds a template for [DockRoute](https://github.com/Dockroute/Dockroute) — External-DNS for plain Docker hosts. It watches running containers, reads `dockroute.*` labels and reconciles the matching DNS records (and Cloudflare Tunnel routes) in a pluggable provider, with ExternalDNS-style TXT ownership so it never alters records it cannot prove it manages.

The default configuration runs the zero-credential `log` provider (dry run), so the template works out of the box with no secrets; switching to Cloudflare is a matter of filling in the env vars from `.env.example`.

## Notes

- The image is multi-arch (amd64 + arm64), published to GHCR by the project's release pipeline.
- The image runs as a non-root user; `DOCKER_SOCK_GID` in `.env.example` documents how to grant it the Docker socket's group.

## Validation

- `vp run validate` — schema + compose validation passed (including this template)
- `vp run test` — 14 passed, 0 failed
- `vp run type-check` and `vp fmt --check` — clean