### PR TITLE
feat: add Kiwix Server template

### DIFF
--- a/templates/kiwix-serve/.env.example
+++ b/templates/kiwix-serve/.env.example
@@ -1,0 +1,5 @@
+APP_PORT=8080
+# Ensure this directory exists and is writable on the host
+ZIM_PATH=/data/zim
+# Optional: URL to download a ZIM file on startup, comment/remove to disable. Only supports one URL.
+DOWNLOAD_URL="https://lb.download.kiwix.org/zim/other/openzim_en_all_maxi_2026-08.zim"

--- a/templates/kiwix-serve/README.md
+++ b/templates/kiwix-serve/README.md
@@ -1,0 +1,15 @@
+# Kiwix Server
+
+[kiwix-serve](https://wiki.kiwix.org/wiki/Kiwix-serve) is a lightweight web server
+that allows you to serve ZIM archives.
+
+## Before deploying
+
+Review the template environment variables:
+
+1. Set `APP_PORT` to the port you want to use for the Kiwix server (default is 8080).
+2. Set `ZIM_PATH` to the directory where you want to store ZIM files.
+   This directory should be writable by the container and
+   needs to contain at least one `.zim` file.
+3. Optionally set `DOWNLOAD_URL` to the URL of a ZIM file to download on startup.
+   This variable only takes one URL.

--- a/templates/kiwix-serve/compose.yaml
+++ b/templates/kiwix-serve/compose.yaml
@@ -1,0 +1,29 @@
+x-arcane:
+  icon-light: https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/kiwix-light.svg
+  icon-dark: https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/kiwix-dark.svg
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/kiwix.svg
+  urls:
+    - https://kiwix.org/en/
+    - https://wiki.kiwix.org/wiki/Kiwix-serve
+    - https://kiwix-tools.readthedocs.io/en/latest/kiwix-serve.html
+    - https://github.com/kiwix/kiwix-tools/tree/main/docker/server
+
+services:
+  kiwix:
+    container_name: kiwix
+    image: ghcr.io/kiwix/kiwix-serve:latest
+    ports:
+      - ${APP_PORT:-8080}:8080
+    volumes:
+      - ${ZIM_PATH}:/data
+    environment:
+      - DOWNLOAD=${DOWNLOAD_URL:-}
+    command: ["*.zim"]
+    healthcheck:
+      test:
+        ["CMD", "wget", "--spider", "--tries=1", "-q", "http://localhost:8080/catalog/v2/root.xml"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    restart: unless-stopped

--- a/templates/kiwix-serve/template.json
+++ b/templates/kiwix-serve/template.json
@@ -1,0 +1,7 @@
+{
+  "name": "Kiwix Server",
+  "description": "A server for hosting Kiwix (.zim) archives, useful for offline access to Wikipedia and other content.",
+  "author": "LeviSnoot",
+  "version": "1.0.0",
+  "tags": ["archive", "local", "wiki"]
+}


### PR DESCRIPTION
# `kiwix-serve`

Adds template for [kiwix-serve](https://wiki.kiwix.org/wiki/Kiwix-serve) ([src](https://github.com/kiwix/kiwix-tools/tree/main/docker/server)).

- Includes healthcheck and restart policy on top of upstream's example compose.
- Sets default `APP_PORT` (`8080`), `ZIM_PATH` (`/tmp/zim`) and `DOWNLOAD_URL` (optional, downloads a small `.zim` by default).

### Caveats

- Requires a `.zim` to exist in `ZIM_PATH` before deployment due to the startup command glob.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an Arcane template for running Kiwix Server with a configurable archive directory, optional startup download, healthcheck, and restart policy.
- Publishes Kiwix metadata and documentation.
- Maps the configured application port and host ZIM directory.
- Supports downloading one archive before startup.
- Adds a catalog health probe.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The template should not merge until startup reliably serves archives downloaded from valid URLs whose basenames include query parameters or otherwise do not match `*.zim`.

Supplying the wildcard command bypasses the image entrypoint's exact downloaded-filename handling, allowing a successfully downloaded archive to be excluded from server startup.

**Files Needing Attention:** templates/kiwix-serve/compose.yaml
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Ftemplates%22%20on%20the%20existing%20branch%20%22tmpl%2Fkiwix-serve%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22tmpl%2Fkiwix-serve%22.%0A%0AGreploop%20getarcaneapp%2Ftemplates%20PR%20%23170%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=getarcaneapp%2Ftemplates&pr=170&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Ftemplates%22%20on%20the%20existing%20branch%20%22tmpl%2Fkiwix-serve%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22tmpl%2Fkiwix-serve%22.%0A%0A%23%23%23%20Issue%201%0Atemplates%2Fkiwix-serve%2Fcompose.yaml%3A21%0A**Wildcard%20bypasses%20downloaded%20filename**%0A%0AWhen%20%60DOWNLOAD_URL%60%20has%20a%20basename%20that%20does%20not%20end%20literally%20in%20%60.zim%60%2C%20such%20as%20a%20URL%20with%20query%20parameters%2C%20this%20explicit%20argument%20bypasses%20the%20entrypoint%20branch%20that%20appends%20the%20exact%20downloaded%20filename.%20The%20resulting%20%60*.zim%60%20does%20not%20match%20the%20downloaded%20file%2C%20causing%20the%20fresh%20deployment%20to%20exit%20and%20restart%20without%20serving%20it.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Ftemplates&pr=170&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atemplates%2Fkiwix-serve%2Fcompose.yaml%3A21%0A**Wildcard%20bypasses%20downloaded%20filename**%0A%0AWhen%20%60DOWNLOAD_URL%60%20has%20a%20basename%20that%20does%20not%20end%20literally%20in%20%60.zim%60%2C%20such%20as%20a%20URL%20with%20query%20parameters%2C%20this%20explicit%20argument%20bypasses%20the%20entrypoint%20branch%20that%20appends%20the%20exact%20downloaded%20filename.%20The%20resulting%20%60*.zim%60%20does%20not%20match%20the%20downloaded%20file%2C%20causing%20the%20fresh%20deployment%20to%20exit%20and%20restart%20without%20serving%20it.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Ftemplates&pr=170&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Atemplates%2Fkiwix-serve%2Fcompose.yaml%3A21%0A**Wildcard%20bypasses%20downloaded%20filename**%0A%0AWhen%20%60DOWNLOAD_URL%60%20has%20a%20basename%20that%20does%20not%20end%20literally%20in%20%60.zim%60%2C%20such%20as%20a%20URL%20with%20query%20parameters%2C%20this%20explicit%20argument%20bypasses%20the%20entrypoint%20branch%20that%20appends%20the%20exact%20downloaded%20filename.%20The%20resulting%20%60*.zim%60%20does%20not%20match%20the%20downloaded%20file%2C%20causing%20the%20fresh%20deployment%20to%20exit%20and%20restart%20without%20serving%20it.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=170&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
templates/kiwix-serve/compose.yaml:21
**Wildcard bypasses downloaded filename**

When `DOWNLOAD_URL` has a basename that does not end literally in `.zim`, such as a URL with query parameters, this explicit argument bypasses the entrypoint branch that appends the exact downloaded filename. The resulting `*.zim` does not match the downloaded file, causing the fresh deployment to exit and restart without serving it.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add Kiwix Server template"](https://github.com/getarcaneapp/templates/commit/cb845e540b8920d71f3271b4385114251d691539) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55521466)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->