### PR TITLE
feat: add Homarr template

### DIFF
--- a/templates/homarr/.env.example
+++ b/templates/homarr/.env.example
@@ -1,0 +1,3 @@
+# `SECRET_ENCRYPTION_KEY` must be set, generate with: `openssl rand -hex 32`
+SECRET_ENCRYPTION_KEY=
+APP_PORT=7575

--- a/templates/homarr/compose.yml
+++ b/templates/homarr/compose.yml
@@ -1,0 +1,23 @@
+x-arcane:
+  icon-light: https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/homarr-light.svg
+  icon-dark: https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/homarr-dark.svg
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/homarr.svg
+  urls:
+    - https://homarr.dev/
+    - https://github.com/homarr-labs/homarr
+
+services:
+  homarr:
+    container_name: homarr
+    image: ghcr.io/homarr-labs/homarr:latest
+    restart: unless-stopped
+    volumes:
+      # - /var/run/docker.sock:/var/run/docker.sock # Optional, only if you want docker integration
+      - homarr_data:/appdata
+    environment:
+      - SECRET_ENCRYPTION_KEY=${SECRET_ENCRYPTION_KEY}
+    ports:
+      - "${APP_PORT:-7575}:7575"
+
+volumes:
+  homarr_data:

--- a/templates/homarr/template.json
+++ b/templates/homarr/template.json
@@ -1,0 +1,7 @@
+{
+  "name": "Homarr",
+  "description": "A modern and easy to use dashboard. 40+ integrations. 20K+ icons built in. Authentication out of the box. No YAML, drag and drop configuration.",
+  "author": "LeviSnoot",
+  "version": "1.0.0",
+  "tags": ["dashboard", "home", "server"]
+}


### PR DESCRIPTION
Adds https://homarr.dev to the template repository.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Adds Homarr as a new Arcane catalog template.
- Defines a single Homarr container with persistent `/appdata` storage and optional Docker integration.
- Publishes port and encryption-key configuration through `.env.example`.
- Adds catalog metadata, tags, icons, and project links.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The Homarr image contract aligns with the declared port, persistent mount, and environment variable, while the required manual secret setup is clearly documented beside the blank configuration value.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add Homarr template"](https://github.com/getarcaneapp/templates/commit/97407f2cbf272d4400655487b86fa0996391a127) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56003709)</sub>

<!-- /greptile_comment -->