### PR TITLE
feat: add Jellystat template

### DIFF
--- a/templates/jellystat/.env.example
+++ b/templates/jellystat/.env.example
@@ -1,0 +1,5 @@
+APP_PORT=3000 # Port to expose app on
+POSTGRES_USER=postgres # Can be changed
+POSTGRES_PASSWORD=mypassword # Change to secure password
+JWT_SECRET=my-secret-jwt-key # Change to secure random string
+TZ=Etc/UTC # timezone (ex: Europe/Paris)

--- a/templates/jellystat/compose.yml
+++ b/templates/jellystat/compose.yml
@@ -1,0 +1,65 @@
+x-arcane:
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons@main/png/jellystat.png
+  urls:
+    - https://github.com/CyferShepard/Jellystat
+
+services:
+  jellystat-db:
+    image: postgres:18.1
+    shm_size: "1gb"
+    container_name: jellystat-db
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "5"
+        max-size: "10m"
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres-data:/var/lib/postgresql
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready --dbname=postgres --username=postgres
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  jellystat:
+    image: cyfershepard/jellystat:latest
+    container_name: jellystat
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "5"
+        max-size: "10m"
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_IP: jellystat-db
+      POSTGRES_PORT: 5432
+      JWT_SECRET: ${JWT_SECRET}
+      TZ: ${TZ:-Etc/UTC}
+    volumes:
+      - jellystat-backup-data:/app/backend/backup-data
+    ports:
+      - "${APP_PORT:-3000}:3000"
+    depends_on:
+      jellystat-db:
+        condition: service_healthy
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:3000/auth/isConfigured || exit 1
+      interval: 60s
+      timeout: 30s
+      retries: 5
+      start_period: 30s
+
+networks:
+  default:
+
+volumes:
+  postgres-data:
+  jellystat-backup-data:

--- a/templates/jellystat/template.json
+++ b/templates/jellystat/template.json
@@ -1,0 +1,7 @@
+{
+  "name": "Jellystat",
+  "description": "A free and open source Statistics App for Jellyfin",
+  "author": "LeviSnoot",
+  "version": "1.0.0",
+  "tags": ["jellyfin", "media", "statistics", "monitoring"]
+}


### PR DESCRIPTION
Adds https://github.com/CyferShepard/Jellystat to the template repository.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an Arcane catalog template for deploying Jellystat with PostgreSQL.

- Defines Jellystat and PostgreSQL services, persistent volumes, readiness checks, and configurable credentials.
- Adds the published environment example and catalog metadata.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The database-insensitive application health check should be corrected before merging because it can report a nonfunctional Jellystat deployment as healthy.

Jellystat’s health check only tests the configuration endpoint, which can remain successful after PostgreSQL becomes unavailable even though the application’s database-backed functionality no longer works.

**Files Needing Attention:** templates/jellystat/compose.yml
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Ftemplates%22%20on%20the%20existing%20branch%20%22tmpl%2Fjellystat%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22tmpl%2Fjellystat%22.%0A%0AGreploop%20getarcaneapp%2Ftemplates%20PR%20%23173%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=getarcaneapp%2Ftemplates&pr=173&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Ftemplates%22%20on%20the%20existing%20branch%20%22tmpl%2Fjellystat%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22tmpl%2Fjellystat%22.%0A%0A%23%23%23%20Issue%201%0Atemplates%2Fjellystat%2Fcompose.yml%3A53%0A**Health%20check%20ignores%20database%20loss**%0A%0AWhen%20PostgreSQL%20becomes%20unavailable%20after%20startup%2C%20%60%2Fauth%2FisConfigured%60%20continues%20returning%20success%2C%20causing%20Docker%20and%20Arcane%20to%20report%20Jellystat%20as%20healthy%20while%20its%20database-backed%20operations%20are%20unavailable.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Ftemplates&pr=173&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atemplates%2Fjellystat%2Fcompose.yml%3A53%0A**Health%20check%20ignores%20database%20loss**%0A%0AWhen%20PostgreSQL%20becomes%20unavailable%20after%20startup%2C%20%60%2Fauth%2FisConfigured%60%20continues%20returning%20success%2C%20causing%20Docker%20and%20Arcane%20to%20report%20Jellystat%20as%20healthy%20while%20its%20database-backed%20operations%20are%20unavailable.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Ftemplates&pr=173&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Atemplates%2Fjellystat%2Fcompose.yml%3A53%0A**Health%20check%20ignores%20database%20loss**%0A%0AWhen%20PostgreSQL%20becomes%20unavailable%20after%20startup%2C%20%60%2Fauth%2FisConfigured%60%20continues%20returning%20success%2C%20causing%20Docker%20and%20Arcane%20to%20report%20Jellystat%20as%20healthy%20while%20its%20database-backed%20operations%20are%20unavailable.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=173&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
templates/jellystat/compose.yml:53
**Health check ignores database loss**

When PostgreSQL becomes unavailable after startup, `/auth/isConfigured` continues returning success, causing Docker and Arcane to report Jellystat as healthy while its database-backed operations are unavailable.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add Jellystat template"](https://github.com/getarcaneapp/templates/commit/d0e0074a4c39ebd932574df74b8168e0ed6d443f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56003763)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Template metadata and configuration contracts](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/templates/-/docs/template-contracts.md)
- Knowledge Base — [Container composition patterns](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/templates/-/docs/container-composition.md)
- Knowledge Base — [Data stores and storage services](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/templates/-/docs/data-stores-and-storage-services.md)
</details>


<!-- /greptile_comment -->